### PR TITLE
Fix yield and `x = {x : {x = 0} } = 0`

### DIFF
--- a/src/main/java/com/shapesecurity/shift/parser/EarlyErrorState.java
+++ b/src/main/java/com/shapesecurity/shift/parser/EarlyErrorState.java
@@ -12,6 +12,7 @@ import com.shapesecurity.shift.ast.MemberExpression;
 import com.shapesecurity.shift.ast.NewTargetExpression;
 import com.shapesecurity.shift.ast.Node;
 import com.shapesecurity.shift.ast.Super;
+import com.shapesecurity.shift.ast.YieldExpression;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -39,7 +40,8 @@ public class EarlyErrorState {
             @NotNull MultiHashTable<String, Node> exportedBindings,
             @NotNull ImmutableList<Super> superCallExpressions,
             @NotNull ImmutableList<Super> superCallExpressionsInConstructorMethod,
-            @NotNull ImmutableList<MemberExpression> superPropertyExpressions) {
+            @NotNull ImmutableList<MemberExpression> superPropertyExpressions,
+            @NotNull ImmutableList<Node> yieldExpressions) {
         this.errors = errors;
         this.strictErrors = strictErrors;
         this.usedLabelNames = usedLabelNames;
@@ -59,6 +61,7 @@ public class EarlyErrorState {
         this.superCallExpressions = superCallExpressions;
         this.superCallExpressionsInConstructorMethod = superCallExpressionsInConstructorMethod;
         this.superPropertyExpressions = superPropertyExpressions;
+        this.yieldExpressions = yieldExpressions;
     }
 
     // Identity
@@ -82,6 +85,7 @@ public class EarlyErrorState {
         this.superCallExpressions = ImmutableList.nil();
         this.superCallExpressionsInConstructorMethod = ImmutableList.nil();
         this.superPropertyExpressions = ImmutableList.nil();
+        this.yieldExpressions = ImmutableList.nil();
     }
 
     // Append
@@ -105,6 +109,7 @@ public class EarlyErrorState {
         this.superCallExpressions = a.superCallExpressions.append(b.superCallExpressions);
         this.superCallExpressionsInConstructorMethod = a.superCallExpressionsInConstructorMethod.append(b.superCallExpressionsInConstructorMethod);
         this.superPropertyExpressions = a.superPropertyExpressions.append(b.superPropertyExpressions);
+        this.yieldExpressions = a.yieldExpressions.append(b.yieldExpressions);
     }
 
 
@@ -171,6 +176,9 @@ public class EarlyErrorState {
     // MemberExpressions with Super object
     @NotNull
     public final ImmutableList<MemberExpression> superPropertyExpressions;
+    // YieldExpressions which may be within parameters / concise arrow bodies
+    @NotNull
+    public final ImmutableList<Node> yieldExpressions;
 
 
     @NotNull
@@ -194,7 +202,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -219,7 +228,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -244,7 +254,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -269,7 +280,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -294,7 +306,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -319,7 +332,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -344,7 +358,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -369,7 +384,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -394,7 +410,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -419,7 +436,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -444,7 +462,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -469,7 +488,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -494,7 +514,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -519,7 +540,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions.cons(node),
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -544,7 +566,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 ImmutableList.nil(),
                 this.superCallExpressions,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -569,7 +592,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 ImmutableList.nil(),
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -594,7 +618,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 ImmutableList.nil(),
                 ImmutableList.nil(),
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -619,7 +644,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 ImmutableList.nil(),
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -644,7 +670,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions.cons(memberExpression)
+                this.superPropertyExpressions.cons(memberExpression),
+                this.yieldExpressions
         );
     }
 
@@ -669,7 +696,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                ImmutableList.nil()
+                ImmutableList.nil(),
+                this.yieldExpressions
         );
     }
 
@@ -694,7 +722,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                ImmutableList.nil()
+                ImmutableList.nil(),
+                this.yieldExpressions
         );
     }
 
@@ -719,7 +748,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -744,7 +774,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -769,7 +800,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -794,7 +826,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -819,7 +852,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -844,7 +878,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -873,7 +908,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -902,7 +938,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -929,7 +966,8 @@ public class EarlyErrorState {
                 res.exportedBindings,
                 res.superCallExpressions,
                 res.superCallExpressionsInConstructorMethod,
-                res.superPropertyExpressions
+                res.superPropertyExpressions,
+                res.yieldExpressions
         );
     }
 
@@ -954,7 +992,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -979,7 +1018,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1004,7 +1044,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1029,7 +1070,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1054,7 +1096,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1079,7 +1122,8 @@ public class EarlyErrorState {
                 this.exportedBindings.merge(this.lexicallyDeclaredNames.mapValues(bi -> (Node) bi)).merge(this.varDeclaredNames.mapValues(bi -> (Node) bi)),
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1104,7 +1148,8 @@ public class EarlyErrorState {
                 this.exportedBindings.put(name, node),
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1129,7 +1174,60 @@ public class EarlyErrorState {
                 MultiHashTable.empty(),
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
+        );
+    }
+
+    @NotNull
+    public EarlyErrorState observeYieldExpression(@NotNull Node yieldExpression) {
+        return new EarlyErrorState(
+                this.errors,
+                this.strictErrors,
+                this.usedLabelNames,
+                this.freeBreakStatements,
+                this.freeContinueStatements,
+                this.freeLabeledBreakStatements,
+                this.freeLabeledContinueStatements,
+                this.newTargetExpressions,
+                this.boundNames,
+                this.previousLexicallyDeclaredNames,
+                this.lexicallyDeclaredNames,
+                this.functionDeclarationNames,
+                this.varDeclaredNames,
+                this.forOfVarDeclaredNames,
+                this.exportedNames,
+                this.exportedBindings,
+                this.superCallExpressions,
+                this.superCallExpressionsInConstructorMethod,
+                this.superPropertyExpressions,
+                this.yieldExpressions.cons(yieldExpression)
+        );
+    }
+
+    @NotNull
+    public EarlyErrorState clearYieldExpressions() {
+        return new EarlyErrorState(
+                this.errors,
+                this.strictErrors,
+                this.usedLabelNames,
+                this.freeBreakStatements,
+                this.freeContinueStatements,
+                this.freeLabeledBreakStatements,
+                this.freeLabeledContinueStatements,
+                this.newTargetExpressions,
+                this.boundNames,
+                this.previousLexicallyDeclaredNames,
+                this.lexicallyDeclaredNames,
+                this.functionDeclarationNames,
+                this.varDeclaredNames,
+                this.forOfVarDeclaredNames,
+                this.exportedNames,
+                this.exportedBindings,
+                this.superCallExpressions,
+                this.superCallExpressionsInConstructorMethod,
+                this.superPropertyExpressions,
+                ImmutableList.nil()
         );
     }
 
@@ -1154,7 +1252,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1179,7 +1278,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1204,7 +1304,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1229,7 +1330,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 
@@ -1254,7 +1356,8 @@ public class EarlyErrorState {
                 this.exportedBindings,
                 this.superCallExpressions,
                 this.superCallExpressionsInConstructorMethod,
-                this.superPropertyExpressions
+                this.superPropertyExpressions,
+                this.yieldExpressions
         );
     }
 

--- a/src/main/java/com/shapesecurity/shift/parser/ErrorMessages.java
+++ b/src/main/java/com/shapesecurity/shift/parser/ErrorMessages.java
@@ -26,6 +26,7 @@ import com.shapesecurity.shift.ast.LabeledStatement;
 import com.shapesecurity.shift.ast.MemberExpression;
 import com.shapesecurity.shift.ast.Node;
 import com.shapesecurity.shift.ast.Super;
+import com.shapesecurity.shift.ast.YieldExpression;
 import com.shapesecurity.shift.codegen.CodeGen;
 
 interface ErrorMessages {
@@ -115,5 +116,8 @@ interface ErrorMessages {
     F<Node, EarlyError> LEXICAL_LET_BINDING = node -> new EarlyError(node, "Lexical declarations must not have a binding named \"let\"");
     F<Node, EarlyError> WITH_LABELED_FN = node -> new EarlyError(node, "The body of a with statement must not be a labeled function declaration");
     F<Node, EarlyError> WITH_STRICT = node -> new EarlyError(node, "Strict mode code must not include a with statement");
+    F<Node, EarlyError> YIELD_IN_ARROW_BODY = node -> new EarlyError(node, "Concise arrow bodies must not contain yield expressions");
+    F<Node, EarlyError> YIELD_IN_ARROW_PARAMS = node -> new EarlyError(node, "Arrow parameters must not contain yield expressions");
+    F<Node, EarlyError> YIELD_IN_GENERATOR_PARAMS = node -> new EarlyError(node, "Generator parameters must not contain yield expressions");
 
 }

--- a/src/main/java/com/shapesecurity/shift/parser/Parser.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Parser.java
@@ -1524,7 +1524,7 @@ public abstract class Parser extends Tokenizer {
                 // falls through
             case LET:
             case IDENTIFIER:
-                return Either.left(new IdentifierExpression(this.lex().toString()));
+                return Either.left(this.markLocation(startLocation, new IdentifierExpression(this.lex().toString())));
             case TRUE_LITERAL:
                 this.lex();
                 this.isBindingElement = this.isAssignmentTarget = false;

--- a/src/test/java/com/shapesecurity/shift/parser/EarlyErrorsTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/EarlyErrorsTest.java
@@ -94,7 +94,7 @@ public class EarlyErrorsTest extends ParserTestCase {
     }
 
     @Test
-    public void testEarlyErrors() throws JsError { // TODO these should also have indices
+    public void testScriptEarlyErrors() throws JsError { // TODO these should also have indices
 
         // 12.1.1
         // It is a Syntax Error if the code matched by this production is contained in strict code and the StringValue of Identifier is "arguments" or "eval".
@@ -496,6 +496,20 @@ public class EarlyErrorsTest extends ParserTestCase {
         testScriptEarlyError("function f(){ labelA: while(0) continue labelB; }", "Continue statement must be nested within an iteration statement with label \"labelB\"");
 
         // 14.2.1
+        // It is a Syntax Error if ArrowParameters Contains YieldExpression is true.
+        testScriptEarlyError("function* g(){ (a = yield) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ (a = yield b) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ (a = yield* b) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ (a = x + f(yield)) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({[yield]: a}) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({a = yield}) => 0; }", "Arrow parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ([a = yield]) => 0; }", "Arrow parameters must not contain yield expressions");
+        // TODO: testScriptEarlyError("function* g(){ (...{a = yield}) => 0; }", "Arrow parameters must not contain yield expressions");
+        // It is a Syntax Error if ConciseBody Contains YieldExpression is true.
+        testScriptEarlyError("function* g(){ () => yield; }", "Concise arrow bodies must not contain yield expressions");
+        testScriptEarlyError("function* g(){ () => yield b; }", "Concise arrow bodies must not contain yield expressions");
+        testScriptEarlyError("function* g(){ () => yield* b; }", "Concise arrow bodies must not contain yield expressions");
+        testScriptEarlyError("function* g(){ () => f(x + (yield)); }", "Concise arrow bodies must not contain yield expressions");
         // It is a Syntax Error if any element of the BoundNames of ArrowParameters also occurs in the LexicallyDeclaredNames of ConciseBody.
         testScriptEarlyError("(a) => { let a; }", "Duplicate binding \"a\"");
         testScriptEarlyError("([a]) => { let a; }", "Duplicate binding \"a\"");
@@ -527,6 +541,15 @@ public class EarlyErrorsTest extends ParserTestCase {
         // It is a Syntax Error if HasDirectSuper of GeneratorMethod is true .
         testScriptEarlyError("!{ *f(a = super()){} };", "Calls to super must be in the \"constructor\" method of a class expression or class declaration that has a superclass");
         testScriptEarlyError("!{ *f(a) { super() } };", "Calls to super must be in the \"constructor\" method of a class expression or class declaration that has a superclass");
+        // It is a Syntax Error if StrictFormalParameters Contains YieldExpression is true.
+        testScriptEarlyError("function* g(){ ({ *m(a = yield){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m(a = yield b){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m(a = yield* b){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m(a = x + f(yield)){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m({[yield]: a}){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m({a = yield}){} }); }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ ({ *m([a = yield]){} }); }", "Generator parameters must not contain yield expressions");
+        // TODO: testScriptEarlyError("function* g(){ ({ *m(...{a = yield}){} }); }", "Generator parameters must not contain yield expressions");
         // It is a Syntax Error if any element of the BoundNames of StrictFormalParameters also occurs in the LexicallyDeclaredNames of GeneratorBody.
         testScriptEarlyError("!{ *f(a) { let a; } };", "Duplicate binding \"a\"");
         testScriptEarlyError("!{ *f([a]){ let a; } };", "Duplicate binding \"a\"");
@@ -550,6 +573,23 @@ public class EarlyErrorsTest extends ParserTestCase {
         testScriptEarlyError("function* f(a) { let a; }", "Duplicate binding \"a\"");
         testScriptEarlyError("function* f([a]){ let a; }", "Duplicate binding \"a\"");
         testScriptEarlyError("function* f({a}){ let a; }", "Duplicate binding \"a\"");
+        // It is a Syntax Error if FormalParameters Contains YieldExpression is true.
+        testScriptEarlyError("function* g(){ function* f(a = yield){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f(a = yield b){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f(a = yield* b){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f(a = x + f(yield)){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f({[yield]: a}){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f({a = yield}){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ function* f([a = yield]){} }", "Generator parameters must not contain yield expressions");
+        // TODO: testScriptEarlyError("function* g(){ function* f(...{a = yield}){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*(a = yield){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*(a = yield b){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*(a = yield* b){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*(a = x + f(yield)){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*({[yield]: a}){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*({a = yield}){} }", "Generator parameters must not contain yield expressions");
+        testScriptEarlyError("function* g(){ !function*([a = yield]){} }", "Generator parameters must not contain yield expressions");
+        // TODO: testEarlyError("function* g(){ !function*(...{a = yield}){} }", "Generator parameters must not contain yield expressions");
         // It is a Syntax Error if FormalParameters Contains SuperProperty is true.
         testScriptEarlyError("function* f(a = super.b){}", "Member access on super must be in a method");
         testScriptEarlyError("!function* (a = super.b){}", "Member access on super must be in a method");

--- a/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
@@ -26,7 +26,7 @@ public class GeneratorDeclarationTest extends ParserTestCase {
                 ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil())));
 
         testScript("function* a(a=yield){}", new FunctionDeclaration(new BindingIdentifier("a"), true, new FormalParameters(
-                ImmutableList.list(new BindingWithDefault(new BindingIdentifier("a"), new IdentifierExpression("yield"))),
+                ImmutableList.list(new BindingWithDefault(new BindingIdentifier("a"), new YieldExpression(Maybe.nothing()))),
                 Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil())));
 
         testScript("function* a({[yield]:a}){}", new FunctionDeclaration(new BindingIdentifier("a"), true,
@@ -53,11 +53,17 @@ public class GeneratorDeclarationTest extends ParserTestCase {
                         new FunctionDeclaration(new BindingIdentifier("a"), false, new FormalParameters(ImmutableList.nil(),
                                 Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil()))))));
 
+        testScript("function*g() { (function*(x = yield){}); }", new FunctionDeclaration(new BindingIdentifier("g"), true, new FormalParameters(ImmutableList.nil(), Maybe.nothing()),
+                new FunctionBody(ImmutableList.nil(), ImmutableList.list(new ExpressionStatement(new FunctionExpression(Maybe.nothing(), true,
+                        new FormalParameters(ImmutableList.list(new BindingWithDefault(new BindingIdentifier("x"), new YieldExpression(Maybe.nothing()))), Maybe.nothing()),
+                        new FunctionBody(ImmutableList.nil(), ImmutableList.nil()))
+                )))));
+
         testScriptFailure("label: function* a(){}", 15, "Unexpected token \"*\"");
+        testScriptFailure("function*g(yield){}", 11, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { var yield; }", 19, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { var yield = 1; }", 19, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { function yield(){}; }", 24, "Unexpected token \"yield\"");
-        testScriptFailure("function*g() { (function yield(){}); }", 25, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { let yield; }", 19, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { try {} catch (yield) {} }", 29, "Unexpected token \"yield\"");
     }

--- a/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
@@ -31,7 +31,7 @@ public class GeneratorDeclarationTest extends ParserTestCase {
 
         testScript("function* a({[yield]:a}){}", new FunctionDeclaration(new BindingIdentifier("a"), true,
                 new FormalParameters(ImmutableList.list(new ObjectBinding(ImmutableList.list(new BindingPropertyProperty(
-                        new ComputedPropertyName(new IdentifierExpression("yield")), new BindingIdentifier("a"))))),
+                        new ComputedPropertyName(new YieldExpression(Maybe.nothing())), new BindingIdentifier("a"))))),
                         Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil())));
 
         testScript("function* a(){({[yield]:a}=0)}", new FunctionDeclaration(new BindingIdentifier("a"),
@@ -66,5 +66,12 @@ public class GeneratorDeclarationTest extends ParserTestCase {
         testScriptFailure("function*g() { function yield(){}; }", 24, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { let yield; }", 19, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { try {} catch (yield) {} }", 29, "Unexpected token \"yield\"");
+    }
+
+    @Test
+    public void testWorking() throws JsError {
+        testScript("assignmentResult = { x: { x = 1 } } = value;\n");
+
+
     }
 }

--- a/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/declarations/GeneratorDeclarationTest.java
@@ -59,6 +59,15 @@ public class GeneratorDeclarationTest extends ParserTestCase {
                         new FunctionBody(ImmutableList.nil(), ImmutableList.nil()))
                 )))));
 
+        testScript("function*g() {x = { x: { x = yield } } = 0;}", new FunctionDeclaration(new BindingIdentifier("g"), true, new FormalParameters(ImmutableList.nil(), Maybe.nothing()),
+                new FunctionBody(ImmutableList.nil(), ImmutableList.list(new ExpressionStatement(
+                        new AssignmentExpression(new BindingIdentifier("x"), new AssignmentExpression(new ObjectBinding(ImmutableList.list(
+                                new BindingPropertyProperty(new StaticPropertyName("x"), new ObjectBinding(ImmutableList.list(
+                                        new BindingPropertyIdentifier(new BindingIdentifier("x"), Maybe.just(new YieldExpression(Maybe.nothing())))
+                                ))))),
+                                new LiteralNumericExpression(0.0)))
+                )))));
+
         testScriptFailure("label: function* a(){}", 15, "Unexpected token \"*\"");
         testScriptFailure("function*g(yield){}", 11, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { var yield; }", 19, "Unexpected token \"yield\"");
@@ -66,12 +75,5 @@ public class GeneratorDeclarationTest extends ParserTestCase {
         testScriptFailure("function*g() { function yield(){}; }", 24, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { let yield; }", 19, "Unexpected token \"yield\"");
         testScriptFailure("function*g() { try {} catch (yield) {} }", 29, "Unexpected token \"yield\"");
-    }
-
-    @Test
-    public void testWorking() throws JsError {
-        testScript("assignmentResult = { x: { x = 1 } } = value;\n");
-
-
     }
 }

--- a/src/test/java/com/shapesecurity/shift/parser/destructuring/assignment/ArrayBindingTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/destructuring/assignment/ArrayBindingTest.java
@@ -37,9 +37,9 @@ public class ArrayBindingTest extends ParserTestCase {
         testScriptFailure("[{a=0},{b=0},0] = 0", 14, "Invalid left-hand side in assignment");
         testScriptFailure("[{a=0},...0]", 2, "Illegal property initializer");
         testScriptFailure("[...0,a]=0", 8, "Invalid left-hand side in assignment");
-        testScriptFailure("[...0,{a=0}]=0", 11, "Invalid rest");
-        testScriptFailure("[...{a=0},]", 9, "Invalid rest");
-        testScriptFailure("[...{a=0},]=0", 9, "Invalid rest");
+        testScriptFailure("[...0,{a=0}]=0", 11, "Invalid left-hand side in assignment");
+        testScriptFailure("[...{a=0},]", 9, "Unexpected token \",\"");
+        testScriptFailure("[...{a=0},]=0", 9, "Unexpected token \",\"");
 
         // TODO: new tests added
         testScriptFailure("[0] = 0", 4, "Invalid left-hand side in assignment");

--- a/src/test/java/com/shapesecurity/shift/parser/destructuring/assignment/ObjectBindingTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/destructuring/assignment/ObjectBindingTest.java
@@ -35,6 +35,15 @@ public class ObjectBindingTest extends ParserTestCase {
         testScript("({yield = 0} = 0);", new AssignmentExpression(new ObjectBinding(ImmutableList.list(new BindingPropertyIdentifier(new BindingIdentifier("yield"), Maybe.just(new LiteralNumericExpression(0.0))))), new LiteralNumericExpression(0.0)));
         testScript("let {a:b=c} = 0;", new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Let, ImmutableList.list(new VariableDeclarator(new ObjectBinding(ImmutableList.list(new BindingPropertyProperty(new StaticPropertyName("a"), new BindingWithDefault(new BindingIdentifier("b"), new IdentifierExpression("c"))))), Maybe.just(new LiteralNumericExpression(0.0)))))));
 
+        testScript("(function*() { [...{ x = yield }] = 0; })", new FunctionExpression(Maybe.nothing(), true, new FormalParameters(ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(),
+                ImmutableList.list(
+                        new ExpressionStatement(new AssignmentExpression(
+                                new ArrayBinding(ImmutableList.nil(), Maybe.just(new ObjectBinding(ImmutableList.list(new BindingPropertyIdentifier(new BindingIdentifier("x"), Maybe.just(new YieldExpression(Maybe.nothing()))))))),
+                                new LiteralNumericExpression(0.0)
+                        ))
+                )
+        )));
+
         testScriptFailure("({a = 0});", 2, "Illegal property initializer");
         testScriptFailure("({a} += 0);", 5, "Invalid left-hand side in assignment");
         testScriptFailure("({a,,} = 0)", 4, "Unexpected token \",\"");

--- a/src/test/java/com/shapesecurity/shift/parser/expressions/FunctionExpressionTest.java
+++ b/src/test/java/com/shapesecurity/shift/parser/expressions/FunctionExpressionTest.java
@@ -72,7 +72,16 @@ public class FunctionExpressionTest extends ParserTestCase {
                 ImmutableList.list(new ArrayBinding(ImmutableList.nil(), Maybe.nothing())), Maybe.nothing()), new FunctionBody(
                 ImmutableList.nil(), ImmutableList.nil())));
 
+        testScript("function* g(){ (function yield(){}); }", new FunctionDeclaration(new BindingIdentifier("g"), true, new FormalParameters(ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.list(
+                new ExpressionStatement(new FunctionExpression(Maybe.just(new BindingIdentifier("yield")), false, new FormalParameters(ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil())))
+        ))));
+
+        testScript("(function*(){ (function yield(){}); });", new FunctionExpression(Maybe.nothing(), true, new FormalParameters(ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.list(
+                new ExpressionStatement(new FunctionExpression(Maybe.just(new BindingIdentifier("yield")), false, new FormalParameters(ImmutableList.nil(), Maybe.nothing()), new FunctionBody(ImmutableList.nil(), ImmutableList.nil())))
+        ))));
+
         testScriptFailure("(function(...a, b){})", 14, "Unexpected token \",\"");
         testScriptFailure("(function((a)){})", 10, "Unexpected token \"(\"");
+
     }
 }


### PR DESCRIPTION
All test262 tests parse or fail to parse as expected, excepting those which have runtime SyntaxErrors.
