### PR TITLE
SourceLocation bugfix and temporary solution to store

### DIFF
--- a/src/main/java/com/shapesecurity/shift/parser/Parser.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Parser.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 public abstract class Parser extends Tokenizer {
-    protected static Map<Node, Maybe<SourceSpan>> locations = new HashMap<>();
+    public Map<Node, Maybe<SourceSpan>> locations = new HashMap<>();
 
     private boolean inFunctionBody;
     private boolean module;
@@ -85,7 +85,7 @@ public abstract class Parser extends Tokenizer {
 
     @NotNull
     protected <T extends Node> T markLocation(@NotNull SourceLocation startLocation, @NotNull T node) {
-        Parser.locations.put(
+        locations.put(
                 node,
                 Maybe.just(
                         new SourceSpan(
@@ -102,7 +102,7 @@ public abstract class Parser extends Tokenizer {
         return node;
     }
 
-    public static Maybe<SourceSpan> getLocation(@NotNull Node node) {
+    public Maybe<SourceSpan> getLocation(@NotNull Node node) {
         return locations.get(node);
     }
 

--- a/src/main/java/com/shapesecurity/shift/parser/Parser.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Parser.java
@@ -27,9 +27,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiFunction;
 
 public abstract class Parser extends Tokenizer {
+    protected static Map<Node, Maybe<SourceSpan>> locations = new HashMap<>();
+
     private boolean inFunctionBody;
     private boolean module;
     private boolean strict;
@@ -81,9 +85,12 @@ public abstract class Parser extends Tokenizer {
 
     @NotNull
     protected <T extends Node> T markLocation(@NotNull SourceLocation startLocation, @NotNull T node) {
-        // TODO: actually mark location
-//    node.loc = Maybe.just(new SourceSpan(Maybe.nothing(), startLocation, new SourceLocation(this.lastLine+1, this.lastIndex-this.lastLineStart, this.lastIndex)));
+        Parser.locations.put(node, Maybe.just(new SourceSpan(Maybe.nothing(), startLocation, new SourceLocation(this.lastLine+1, this.lastIndex-this.lastLineStart, this.lastIndex))));
         return node;
+    }
+
+    public static Maybe<SourceSpan> getLocation(@NotNull Node node) {
+        return locations.get(node);
     }
 
     private boolean lookaheadLexicalDeclaration() throws JsError {

--- a/src/main/java/com/shapesecurity/shift/parser/Parser.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Parser.java
@@ -10,11 +10,7 @@
 package com.shapesecurity.shift.parser;
 
 import com.shapesecurity.functional.Pair;
-import com.shapesecurity.functional.Thunk;
-import com.shapesecurity.functional.data.Either;
-import com.shapesecurity.functional.data.Maybe;
-import com.shapesecurity.functional.data.ImmutableList;
-import com.shapesecurity.functional.data.NonEmptyImmutableList;
+import com.shapesecurity.functional.data.*;
 import com.shapesecurity.shift.ast.*;
 import com.shapesecurity.shift.ast.operators.*;
 import com.shapesecurity.shift.parser.token.NumericLiteralToken;
@@ -22,17 +18,14 @@ import com.shapesecurity.shift.parser.token.RegularExpressionLiteralToken;
 import com.shapesecurity.shift.parser.token.StringLiteralToken;
 import com.shapesecurity.shift.parser.token.TemplateToken;
 import com.shapesecurity.shift.utils.D2A;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.BiFunction;
 
 public abstract class Parser extends Tokenizer {
-    public Map<Node, Maybe<SourceSpan>> locations = new HashMap<>();
+    public HashTable<Node, SourceSpan> locations = HashTable.empty();
 
     private boolean inFunctionBody;
     private boolean module;
@@ -85,23 +78,16 @@ public abstract class Parser extends Tokenizer {
 
     @NotNull
     protected <T extends Node> T markLocation(@NotNull SourceLocation startLocation, @NotNull T node) {
-        locations.put(
-                node,
-                Maybe.just(
-                        new SourceSpan(
-                                Maybe.nothing(),
-                                startLocation,
-                                new SourceLocation(
-                                        this.lastLine + 1,
-                                        this.lastIndex - this.lastLineStart,
-                                        this.lastIndex
-                                )
-                        )
-                )
+        SourceLocation endLocation = new SourceLocation(
+                this.lastLine + 1,
+                this.lastIndex - this.lastLineStart,
+                this.lastIndex
         );
+        locations.put(node, new SourceSpan(Maybe.nothing(), startLocation, endLocation));
         return node;
     }
 
+    @NotNull
     public Maybe<SourceSpan> getLocation(@NotNull Node node) {
         return locations.get(node);
     }

--- a/src/main/java/com/shapesecurity/shift/parser/Parser.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Parser.java
@@ -85,7 +85,20 @@ public abstract class Parser extends Tokenizer {
 
     @NotNull
     protected <T extends Node> T markLocation(@NotNull SourceLocation startLocation, @NotNull T node) {
-        Parser.locations.put(node, Maybe.just(new SourceSpan(Maybe.nothing(), startLocation, new SourceLocation(this.lastLine+1, this.lastIndex-this.lastLineStart, this.lastIndex))));
+        Parser.locations.put(
+                node,
+                Maybe.just(
+                        new SourceSpan(
+                                Maybe.nothing(),
+                                startLocation,
+                                new SourceLocation(
+                                        this.lastLine + 1,
+                                        this.lastIndex - this.lastLineStart,
+                                        this.lastIndex
+                                )
+                        )
+                )
+        );
         return node;
     }
 

--- a/src/main/java/com/shapesecurity/shift/parser/Tokenizer.java
+++ b/src/main/java/com/shapesecurity/shift/parser/Tokenizer.java
@@ -1209,6 +1209,8 @@ public class Tokenizer {
         int start = this.index;
 
         this.lastIndex = this.index;
+        this.lastLine = this.line;
+        this.lastLineStart = this.lineStart;
 
         this.skipComment();
 
@@ -1356,6 +1358,8 @@ public class Tokenizer {
                 this.startLine,
                 this.startLineStart,
                 this.lastIndex,
+                this.lastLine,
+                this.lastLineStart,
                 this.lookahead,
                 this.hasLineTerminatorBeforeNext
         );
@@ -1369,6 +1373,8 @@ public class Tokenizer {
         this.startLine = s.startLine;
         this.startLineStart = s.startLineStart;
         this.lastIndex = s.lastIndex;
+        this.lastLine = s.lastLine;
+        this.lastLineStart = s.lastLineStart;
         this.lookahead = s.lookahead;
         this.hasLineTerminatorBeforeNext = s.hasLineTerminatorBeforeNext;
     }

--- a/src/main/java/com/shapesecurity/shift/parser/TokenizerState.java
+++ b/src/main/java/com/shapesecurity/shift/parser/TokenizerState.java
@@ -10,6 +10,8 @@ public class TokenizerState {
     public final int startIndex;
     public final int startLine;
     public final int startLineStart;
+    public final int lastLine;
+    public final int lastLineStart;
     public final int lastIndex;
     @NotNull
     public final Token lookahead;
@@ -23,6 +25,8 @@ public class TokenizerState {
             int startLine,
             int startLineStart,
             int lastIndex,
+            int lastLine,
+            int lastLineStart,
             @NotNull Token lookahead,
             boolean hasLineTerminatorBeforeNext
     ) {
@@ -33,6 +37,8 @@ public class TokenizerState {
         this.startLine = startLine;
         this.startLineStart = startLineStart;
         this.lastIndex = lastIndex;
+        this.lastLine = lastLine;
+        this.lastLineStart = lastLineStart;
         this.lookahead = lookahead;
         this.hasLineTerminatorBeforeNext = hasLineTerminatorBeforeNext;
     }


### PR DESCRIPTION
`TokenizerState` did not save the `lastLine` and `lastLineStart` values, thus they could not be restored. Also the `Tokenizer` did not update the previously mentioned variables while collecting tokens.

I've fixed these issues and used them to calculate and store the start and end source locations of the AST nodes. While the `Node` interface can not be easily transformed into an abstract class containing a reference to its `SourceSpan` (see #92), the `Parser` could temporarily keep a map of these, so users may access them. 

Until a greater refactoring, this solution may be used, and later the introduced `Parser.getLocation(Node)` may just redirect to `Node.getLocation()`.
