### PR TITLE
Fix locations table to use object identity

### DIFF
--- a/src/main/java/com/shapesecurity/shift/parser/ParserWithLocation.java
+++ b/src/main/java/com/shapesecurity/shift/parser/ParserWithLocation.java
@@ -6,7 +6,7 @@ import com.shapesecurity.shift.ast.*;
 import org.jetbrains.annotations.NotNull;
 
 public class ParserWithLocation {
-	protected HashTable<Node, SourceSpan> locations = HashTable.empty();
+	protected HashTable<Node, SourceSpan> locations = HashTable.emptyP();
 
 	public ParserWithLocation() {}
 


### PR DESCRIPTION
Since our nodes have equality overridden, but two equal nodes may have different location, we need `emptyP`.
