### PR TITLE
add WebSafeCodeGen class; fix a CodeGen bug in Directives

### DIFF
--- a/src/main/java/com/shapesecurity/shift/codegen/PrettyCodeGen.java
+++ b/src/main/java/com/shapesecurity/shift/codegen/PrettyCodeGen.java
@@ -1,0 +1,21 @@
+package com.shapesecurity.shift.codegen;
+
+import com.shapesecurity.shift.ast.Module;
+import com.shapesecurity.shift.ast.Script;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class PrettyCodeGen extends CodeGen {
+	private PrettyCodeGen(@NotNull CodeRepFactory factory) {
+		super(factory);
+	}
+
+	@NotNull
+	public static String codeGen(@NotNull Script script) {
+		return codeGen(script, PRETTY);
+	}
+
+	@NotNull
+	public static String codeGen(@NotNull Module module) {
+		return codeGen(module, PRETTY);
+	}
+}

--- a/src/main/java/com/shapesecurity/shift/codegen/TokenStream.java
+++ b/src/main/java/com/shapesecurity/shift/codegen/TokenStream.java
@@ -24,11 +24,11 @@ import org.jetbrains.annotations.Nullable;
 
 class TokenStream {
     @NotNull
-    private final StringBuilder writer;
-    private char lastChar = (char) -1;
+    protected final StringBuilder writer;
+    protected char lastChar = (char) -1;
     @Nullable
-    private String lastNumber;
-    private boolean optionalSemi;
+    protected String lastNumber;
+    protected boolean optionalSemi;
 
     public TokenStream(@NotNull StringBuilder writer) {
         this.writer = writer;

--- a/src/main/java/com/shapesecurity/shift/codegen/WebSafeCodeGen.java
+++ b/src/main/java/com/shapesecurity/shift/codegen/WebSafeCodeGen.java
@@ -1,0 +1,147 @@
+package com.shapesecurity.shift.codegen;
+
+import com.shapesecurity.functional.F;
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.Maybe;
+import com.shapesecurity.shift.ast.BindingIdentifier;
+import com.shapesecurity.shift.ast.Directive;
+import com.shapesecurity.shift.ast.IdentifierExpression;
+import com.shapesecurity.shift.ast.LiteralRegExpExpression;
+import com.shapesecurity.shift.ast.LiteralStringExpression;
+import com.shapesecurity.shift.ast.Module;
+import com.shapesecurity.shift.ast.Script;
+import com.shapesecurity.shift.ast.TemplateElement;
+import com.shapesecurity.shift.ast.TemplateExpression;
+import com.shapesecurity.shift.utils.Utils;
+import com.shapesecurity.shift.visitor.Director;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WebSafeCodeGen extends CodeGen {
+	private WebSafeCodeGen(@NotNull CodeRepFactory factory) {
+		super(factory);
+	}
+
+	@NotNull
+	public static String codeGen(@NotNull Script script) {
+		StringBuilder sb = new StringBuilder();
+		Director.reduceScript(new WebSafeCodeGen(new CodeRepFactory()), script).emit(new WebSafeTokenStream(sb), false);
+		return sb.toString();
+	}
+
+	@NotNull
+	public static String codeGen(@NotNull Module module) {
+		StringBuilder sb = new StringBuilder();
+		Director.reduceModule(new WebSafeCodeGen(new CodeRepFactory()), module).emit(new WebSafeTokenStream(sb), false);
+		return sb.toString();
+	}
+
+	@Override
+	@NotNull
+	public CodeRep reduceLiteralStringExpression(@NotNull LiteralStringExpression node) {
+		return factory.token(safe(Utils.escapeStringLiteral(node.value)));
+	}
+
+	@Override
+	@NotNull
+	public CodeRep reduceLiteralRegExpExpression(@NotNull LiteralRegExpExpression node) {
+		return factory.token("/" + safe(node.pattern + "/") + node.flags);
+	}
+
+	@NotNull
+	@Override
+	public CodeRep reduceIdentifierExpression(@NotNull IdentifierExpression node) {
+		CodeRep a = factory.token(safe(node.name));
+		if (node.name.equals("let")) {
+			a.startsWithLet = true;
+		}
+		return a;
+	}
+
+	@NotNull
+	@Override
+	public CodeRep reduceBindingIdentifier(@NotNull BindingIdentifier node) {
+		CodeRep a = factory.token(safe(node.name));
+		if (node.name.equals("let")) {
+			a.startsWithLet = true;
+		}
+		return a;
+	}
+
+	@NotNull
+	@Override
+	public CodeRep reduceDirective(@NotNull Directive node) {
+		String delim = node.rawValue.matches("^(?:[^\"]|\\\\.)*$") ? "\"" : "\'";
+		return seqVA(factory.token(delim + safe(node.rawValue) + delim), factory.semiOp());
+	}
+
+	@NotNull
+	@Override
+	public CodeRep reduceTemplateExpression(@NotNull TemplateExpression node, @NotNull Maybe<CodeRep> tag, @NotNull ImmutableList<CodeRep> elements) {
+		CodeRep state = node.tag.maybe(factory.empty(), t -> p(t, node.getPrecedence(), tag.just()));
+		state = seqVA(state, factory.token("`"));
+		for (int i = 0, l = node.elements.length; i < l; ++i) {
+			if (node.elements.index(i).just() instanceof TemplateElement) {
+				String d = "";
+				if (i > 0) {
+					d += "}";
+				}
+				d += safe(((TemplateElement) node.elements.index(i).just()).rawValue);
+				if (i < l - 1) {
+					d += "${";
+				}
+				if (d.length() > 0) {
+					state = seqVA(state, factory.token(d));
+				}
+			} else {
+				state = seqVA(state, elements.index(i).just());
+			}
+		}
+		state = seqVA(state, factory.token("`"));
+		if (node.tag.isJust()) {
+			state.startsWithCurly = tag.just().startsWithCurly;
+			state.startsWithLetSquareBracket = tag.just().startsWithLetSquareBracket;
+			state.startsWithFunctionOrClass = tag.just().startsWithFunctionOrClass;
+		}
+		return state;
+	}
+
+	private static Pattern NULL = Pattern.compile("\\x00");
+	private static Pattern NONASCII = Pattern.compile("[\\x80-\\uFFFF]");
+	private static Pattern SCRIPTTAG = Pattern.compile("<(/?)script([\\t\\r\\f />])");
+
+	@NotNull
+	private static String safe(@NotNull String unsafe) {
+		unsafe = replaceAll(NULL, unsafe, "\\x00");
+		unsafe = replaceAll(NONASCII, unsafe, mr -> String.format("\\u%04X", (int) mr.group().charAt(0)));
+		unsafe = replaceAll(SCRIPTTAG, unsafe, mr -> "<" + mr.group(1) + String.format("\\x%02X", (int) 's') + "cript" + mr.group(2));
+		return unsafe;
+	}
+
+	private static Pattern DOLLAR_OR_BACKSLASH = Pattern.compile("[\\\\$]");
+
+	// in order to treat replacement string as literal replacement, escape backslash and dollar sign
+	@NotNull
+	private static String literally(@NotNull String replacement) {
+		return DOLLAR_OR_BACKSLASH.matcher(replacement).replaceAll("\\\\$0");
+	}
+
+	@NotNull
+	private static String replaceAll(@NotNull Pattern pattern, @NotNull String string, @NotNull String replacement) {
+		return pattern.matcher(string).replaceAll(literally(replacement));
+	}
+
+	@NotNull
+	private static String replaceAll(@NotNull Pattern pattern, @NotNull String string, @NotNull F<MatchResult, String> replacer) {
+		StringBuffer output = new StringBuffer();
+		Matcher matcher = pattern.matcher(string);
+		while (matcher.find()) {
+			matcher.appendReplacement(output, literally(replacer.apply(matcher.toMatchResult())));
+		}
+		matcher.appendTail(output);
+		return output.toString();
+	}
+}

--- a/src/main/java/com/shapesecurity/shift/codegen/WebSafeTokenStream.java
+++ b/src/main/java/com/shapesecurity/shift/codegen/WebSafeTokenStream.java
@@ -1,0 +1,21 @@
+package com.shapesecurity.shift.codegen;
+
+import com.shapesecurity.shift.utils.Utils;
+import org.jetbrains.annotations.NotNull;
+
+class WebSafeTokenStream extends TokenStream {
+	public WebSafeTokenStream(@NotNull StringBuilder writer) {
+		super(writer);
+	}
+
+	@Override
+	public void put(@NotNull String tokenStr) {
+		if (
+			this.lastChar == '<' && (tokenStr.startsWith("script") || tokenStr.startsWith("/script")) ||
+            Utils.isIdentifierPart(this.lastChar) && (Utils.isIdentifierPart(tokenStr.charAt(0)) || tokenStr.charAt(0) == '\\')
+		) {
+			writer.append(this.lastChar = ' ');
+		}
+		super.put(tokenStr);
+	}
+}

--- a/src/main/java/com/shapesecurity/shift/utils/Utils.java
+++ b/src/main/java/com/shapesecurity/shift/utils/Utils.java
@@ -58,6 +58,7 @@ public final class Utils {
         return true;
     }
 
+    @NotNull
     public static String escapeStringLiteral(@NotNull String stringValue) {
         int nSingle = 0;
         int nDouble = 0;

--- a/src/test/java/com/shapesecurity/shift/codegen/CodeGenTest.java
+++ b/src/test/java/com/shapesecurity/shift/codegen/CodeGenTest.java
@@ -33,14 +33,14 @@ public class CodeGenTest {
         return new Script(ImmutableList.<Directive>nil(), ImmutableList.list(stmt));
     }
 
-    private void test(String source) throws JsError {
+    private static void test(String source) throws JsError {
         Module module = Parser.parseModule(source);
         String code = CodeGen.codeGen(module);
         assertEquals(source, code);
         assertEquals(module, Parser.parseModule(code));
     }
 
-    private void test(String expected, String source) throws JsError {
+    private static void test(String expected, String source) throws JsError {
         Module module = Parser.parseModule(source);
         String code = CodeGen.codeGen(module);
         assertEquals(expected, code);
@@ -134,6 +134,8 @@ public class CodeGenTest {
         test("\"use strict\"");
         test("\"use\u0020strict\"");
         testShift("\"use\u0020strict\"", new Script(ImmutableList.list(new Directive("use strict")), ImmutableList.nil()));
+        testShift("'\"'", new Script(ImmutableList.list(new Directive("\"")), ImmutableList.nil()));
+        testShift("\"\\\"\"", new Script(ImmutableList.list(new Directive("\\\"")), ImmutableList.nil()));
     }
 
     @Test

--- a/src/test/java/com/shapesecurity/shift/codegen/WebSafeCodeGenTest.java
+++ b/src/test/java/com/shapesecurity/shift/codegen/WebSafeCodeGenTest.java
@@ -1,0 +1,72 @@
+package com.shapesecurity.shift.codegen;
+
+import com.shapesecurity.shift.ast.Module;
+import com.shapesecurity.shift.parser.JsError;
+import com.shapesecurity.shift.parser.Parser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebSafeCodeGenTest {
+	private static void test(String expected, String source) throws JsError {
+        Module module = Parser.parseModule(source);
+		String code = WebSafeCodeGen.codeGen(module);
+		assertEquals(expected, code);
+		assertEquals(module, Parser.parseModule(code));
+	}
+	private static void testWithoutEq(String expected, String source) throws JsError {
+		Module module = Parser.parseModule(source);
+		String code = WebSafeCodeGen.codeGen(module);
+		assertEquals(expected, code);
+	}
+
+	@Test
+	public void testNullByte() throws JsError {
+		test("(\"\\x00\")", "(\"\\0\")");
+		test("(\"\\x00\")", "(\"\0\")");
+		testWithoutEq("\"\\x00\"", "\"\0\"");
+		testWithoutEq("/\\x00/", "/\0/");
+		testWithoutEq("`\\x00`", "`\0`");
+		testWithoutEq("`\\x00${0}\\x00${0}\\x00`", "`\0${0}\0${0}\0`");
+		testWithoutEq("tag`\\x00`", "tag`\0`");
+		testWithoutEq("tag`\\x00${0}\\x00${0}\\x00`", "tag`\0${0}\0${0}\0`");
+	}
+
+	@Test
+	public void testScriptTag() throws JsError {
+		test("a< script", "a<script ");
+		test("a< /script/", "a</script/");
+		test("a<< script", "a<<script ");
+		test("a<< /script/", "a<</script/");
+		test("(\"<\\x73cript \")", "(\"<script \")");
+		test("(\"</\\x73cript \")", "(\"</script \")");
+		testWithoutEq("\"<\\x73cript \"", "\"<script \"");
+		testWithoutEq("\"</\\x73cript \"", "\"</script \"");
+		testWithoutEq("/<\\x73cript/", "/<script/");
+		testWithoutEq("/[</\\x73cript ]/", "/[</script ]/");
+		testWithoutEq("`<\\x73cript `", "`<script `");
+		testWithoutEq("`<\\x73cript ${0}<\\x73cript ${0}<\\x73cript `", "`<script ${0}<script ${0}<script `");
+		testWithoutEq("`</\\x73cript `", "`</script `");
+		testWithoutEq("`</\\x73cript ${0}</\\x73cript ${0}</\\x73cript `", "`</script ${0}</script ${0}</script `");
+		testWithoutEq("tag`<\\x73cript `", "tag`<script `");
+		testWithoutEq("tag`<\\x73cript ${0}<\\x73cript ${0}<\\x73cript `", "tag`<script ${0}<script ${0}<script `");
+		testWithoutEq("tag`</\\x73cript `", "tag`</script `");
+		testWithoutEq("tag`</\\x73cript ${0}</\\x73cript ${0}</\\x73cript `", "tag`</script ${0}</script ${0}</script `");
+	}
+
+	@Test
+	public void testNonAscii() throws JsError {
+		test("\\u03C6", "φ");
+		test("\\u03C6\\u03C6\\u03C6", "φφφ");
+		test("abc\\u03C6xyz", "abcφxyz");
+		test("let \\u03C6", "let φ");
+		test("\\u03C6=0", "φ = 0");
+		test("(\"\\u03C6\")", "(\"φ\")");
+		testWithoutEq("\"\\u03C6\"", "\"φ\"");
+		testWithoutEq("/\\u03C6/", "/φ/");
+		testWithoutEq("`\\u03C6`", "`φ`");
+		testWithoutEq("`\\u03C6${0}\\u03C6${0}\\u03C6`", "`φ${0}φ${0}φ`");
+		testWithoutEq("tag`\\u03C6`", "tag`φ`");
+		testWithoutEq("tag`\\u03C6${0}\\u03C6${0}\\u03C6`", "tag`φ${0}φ${0}φ`");
+	}
+}


### PR DESCRIPTION
WebSafeCodeGen generates ECMAScript code that can safely be put inside a `<script>` tag with no further escaping necessary, while attempting to preserve semantics as much as is possible. Semantics will be altered for directives or tagged templates that contain any of the disallowed characters or sequences of characters.

@bakkot: We will need to port this to the ES2016 branch eventually.
