### PR TITLE
Location fixes: FunctionBody includes braces, FormalParameters includes parentheses

### DIFF
--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeGen.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeGen.java
@@ -183,9 +183,7 @@ public class CodeGen implements Reducer<CodeRep> {
         if (isComplexArrowHead(node.params)) {
             params = factory.paren(params);
         }
-        if (node.body instanceof FunctionBody) {
-            body = factory.brace(body);
-        } else if (body.startsWithCurly()) {
+        if (body.startsWithCurly()) {
             body = factory.paren(body);
         }
         if (node.body instanceof Expression) {
@@ -619,19 +617,19 @@ public class CodeGen implements Reducer<CodeRep> {
         if (statements.isNotEmpty()) {
             ((NonEmptyImmutableList<CodeRep>) statements).head.markIsInDirectivePosition();
         }
-        return seqVA(factory.seq(directives), factory.seq(statements));
+        return factory.brace(seqVA(factory.seq(directives), factory.seq(statements)));
     }
 
     @Override
     @Nonnull
     public CodeRep reduceFunctionDeclaration(@Nonnull FunctionDeclaration node, @Nonnull CodeRep name, @Nonnull CodeRep params, @Nonnull CodeRep body) {
-        return seqVA(factory.token("function"), node.isGenerator ? factory.token("*") : factory.empty(), node.name.name.equals("*default*") ? factory.empty() : name, factory.paren(params), factory.brace(body));
+        return seqVA(factory.token("function"), node.isGenerator ? factory.token("*") : factory.empty(), node.name.name.equals("*default*") ? factory.empty() : name, factory.paren(params), body);
     }
 
     @Override
     @Nonnull
     public CodeRep reduceFunctionExpression(@Nonnull FunctionExpression node, @Nonnull Maybe<CodeRep> name, @Nonnull CodeRep params, @Nonnull CodeRep body) {
-        CodeRep state = seqVA(factory.token("function"), node.isGenerator ? factory.token("*") : factory.empty(), name.isJust() ? name.fromJust() : factory.empty(), factory.paren(params), factory.brace(body));
+        CodeRep state = seqVA(factory.token("function"), node.isGenerator ? factory.token("*") : factory.empty(), name.isJust() ? name.fromJust() : factory.empty(), factory.paren(params), body);
         state.setStartsWithFunctionOrClass(true);
         return state;
     }
@@ -640,7 +638,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Nonnull
     public CodeRep reduceGetter(
             @Nonnull Getter node, @Nonnull CodeRep name, @Nonnull CodeRep body) {
-        return seqVA(factory.token("get"), name, factory.paren(factory.empty()), factory.brace(body));
+        return seqVA(factory.token("get"), name, factory.paren(factory.empty()), body);
     }
 
     @Nonnull
@@ -762,7 +760,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Nonnull
     @Override
     public CodeRep reduceMethod(@Nonnull Method node, @Nonnull CodeRep name, @Nonnull CodeRep params, @Nonnull CodeRep body) {
-        return seqVA(node.isGenerator ? factory.token("*") : factory.empty(), name, factory.paren(params), factory.brace(body));
+        return seqVA(node.isGenerator ? factory.token("*") : factory.empty(), name, factory.paren(params), body);
     }
 
     @Nonnull
@@ -835,7 +833,7 @@ public class CodeGen implements Reducer<CodeRep> {
             @Nonnull CodeRep name,
             @Nonnull CodeRep param,
             @Nonnull CodeRep body) {
-        return (seqVA(factory.token("set"), name, factory.paren(param), factory.brace(body)));
+        return (seqVA(factory.token("set"), name, factory.paren(param), body));
     }
 
     @Nonnull

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeGen.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeGen.java
@@ -184,7 +184,7 @@ public class CodeGen implements Reducer<CodeRep> {
             // FormalParameters unconditionally include parentheses, but they're not necessary here
             params = this.reduceBindingIdentifier((BindingIdentifier) node.params.items.maybeHead().fromJust());
         }
-        if (body.startsWithCurly()) {
+        if (body.startsWithObjectCurly()) {
             body = factory.paren(body);
         }
         if (node.body instanceof Expression) {
@@ -198,7 +198,7 @@ public class CodeGen implements Reducer<CodeRep> {
     public CodeRep reduceAssignmentExpression(@Nonnull AssignmentExpression node, @Nonnull CodeRep leftCode, @Nonnull CodeRep expression) {
         CodeRep rightCode = expression;
         boolean containsIn = expression.containsIn();
-        boolean startsWithCurly = leftCode.startsWithCurly();
+        boolean startsWithCurly = leftCode.startsWithObjectCurly();
         boolean startsWithLetSquareBracket = leftCode.startsWithLetSquareBracket();
         boolean startsWithFunctionOrClass = leftCode.startsWithFunctionOrClass();
         if (node.expression.getPrecedence().ordinal() < node.getPrecedence().ordinal()) {
@@ -207,7 +207,7 @@ public class CodeGen implements Reducer<CodeRep> {
         }
         CodeRep toReturn = seqVA(leftCode, factory.token("="), rightCode);
         toReturn.setContainsIn(containsIn);
-        toReturn.setStartsWithCurly(startsWithCurly);
+        toReturn.startsWithObjectCurly(startsWithCurly);
         toReturn.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         toReturn.setStartsWithFunctionOrClass(startsWithFunctionOrClass);
         return toReturn;
@@ -241,7 +241,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Nonnull
     public CodeRep reduceBinaryExpression(@Nonnull BinaryExpression node, @Nonnull CodeRep left, @Nonnull CodeRep right) {
         CodeRep leftCode = left;
-        boolean startsWithCurly = left.startsWithCurly();
+        boolean startsWithCurly = left.startsWithObjectCurly();
         boolean startsWithLetSquareBracket = left.startsWithLetSquareBracket();
         boolean startsWithFunctionOrClass = left.startsWithFunctionOrClass();
         boolean leftContainsIn = left.containsIn();
@@ -261,7 +261,7 @@ public class CodeGen implements Reducer<CodeRep> {
         CodeRep toReturn = seqVA(leftCode, factory.token(node.operator.getName()), rightCode);
         toReturn.setContainsIn(leftContainsIn || rightContainsIn || node.operator.equals(BinaryOperator.In));
         toReturn.setContainsGroup(node.operator.equals(BinaryOperator.Sequence));
-        toReturn.setStartsWithCurly(startsWithCurly);
+        toReturn.startsWithObjectCurly(startsWithCurly);
         toReturn.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         toReturn.setStartsWithFunctionOrClass(startsWithFunctionOrClass);
         return toReturn;
@@ -322,7 +322,7 @@ public class CodeGen implements Reducer<CodeRep> {
         } else {
             result = seqVA(callee, factory.paren(factory.commaSep(arguments)));
         }
-        result.setStartsWithCurly(callee.startsWithCurly());
+        result.startsWithObjectCurly(callee.startsWithObjectCurly());
         result.setStartsWithLetSquareBracket(callee.startsWithLetSquareBracket());
         result.setStartsWithFunctionOrClass(callee.startsWithFunctionOrClass());
         return result;
@@ -374,7 +374,7 @@ public class CodeGen implements Reducer<CodeRep> {
     public CodeRep reduceCompoundAssignmentExpression(@Nonnull CompoundAssignmentExpression node, @Nonnull CodeRep binding, @Nonnull CodeRep expression) {
         CodeRep rightCode = expression;
         boolean containsIn = expression.containsIn();
-        boolean startsWithCurly = binding.startsWithCurly();
+        boolean startsWithCurly = binding.startsWithObjectCurly();
         boolean startsWithLetSquareBracket = binding.startsWithLetSquareBracket();
         boolean startsWithFunctionOrClass = binding.startsWithFunctionOrClass();
         if (node.expression.getPrecedence().ordinal() < node.getPrecedence().ordinal()) {
@@ -383,7 +383,7 @@ public class CodeGen implements Reducer<CodeRep> {
         }
         CodeRep toReturn = seqVA(binding, factory.token(node.operator.getName()), rightCode);
         toReturn.setContainsIn(containsIn);
-        toReturn.setStartsWithCurly(startsWithCurly);
+        toReturn.startsWithObjectCurly(startsWithCurly);
         toReturn.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         toReturn.setStartsWithFunctionOrClass(startsWithFunctionOrClass);
         return toReturn;
@@ -401,7 +401,7 @@ public class CodeGen implements Reducer<CodeRep> {
         }
         result.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         result.setStartsWithLet(object.startsWithLet());
-        result.setStartsWithCurly(object.startsWithCurly());
+        result.startsWithObjectCurly(object.startsWithObjectCurly());
         result.setStartsWithFunctionOrClass(object.startsWithFunctionOrClass());
         return result;
     }
@@ -418,7 +418,7 @@ public class CodeGen implements Reducer<CodeRep> {
         }
         result.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         result.setStartsWithLet(object.startsWithLet());
-        result.setStartsWithCurly(object.startsWithCurly());
+        result.startsWithObjectCurly(object.startsWithObjectCurly());
         result.setStartsWithFunctionOrClass(object.startsWithFunctionOrClass());
         return result;
     }
@@ -433,13 +433,13 @@ public class CodeGen implements Reducer<CodeRep> {
     @Nonnull
     public CodeRep reduceConditionalExpression(@Nonnull ConditionalExpression node, @Nonnull CodeRep test, @Nonnull CodeRep consequent, @Nonnull CodeRep alternate) {
         boolean containsIn = test.containsIn() || alternate.containsIn();
-        boolean startsWithCurly = test.startsWithCurly();
+        boolean startsWithCurly = test.startsWithObjectCurly();
         boolean startsWithLetSquareBracket = test.startsWithLetSquareBracket();
         boolean startsWithFunctionOrClass = test.startsWithFunctionOrClass();
 
         CodeRep toReturn = seqVA(p(node.test, Precedence.LOGICAL_OR, test), factory.token("?"), p(node.consequent, Precedence.ASSIGNMENT, consequent), factory.token(":"), p(node.alternate, Precedence.ASSIGNMENT, alternate));
         toReturn.setContainsIn(containsIn);
-        toReturn.setStartsWithCurly(startsWithCurly);
+        toReturn.startsWithObjectCurly(startsWithCurly);
         toReturn.setStartsWithLetSquareBracket(startsWithLetSquareBracket);
         toReturn.setStartsWithFunctionOrClass(startsWithFunctionOrClass);
         return toReturn;
@@ -553,7 +553,7 @@ public class CodeGen implements Reducer<CodeRep> {
         if (expressionStatement.expression instanceof LiteralStringExpression) {
             return factory.markStringLiteralExpressionStatement(expression);
         }
-        boolean needsParens = expression.startsWithCurly() || expression.startsWithLetSquareBracket() || expression.startsWithFunctionOrClass();
+        boolean needsParens = expression.startsWithObjectCurly() || expression.startsWithLetSquareBracket() || expression.startsWithFunctionOrClass();
         return seqVA((needsParens ? factory.paren(expression) : expression), factory.semiOp());
     }
 
@@ -790,7 +790,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Override
     public CodeRep reduceObjectAssignmentTarget(@Nonnull ObjectAssignmentTarget node, @Nonnull ImmutableList<CodeRep> properties) {
         CodeRep state = factory.brace(factory.commaSep(properties));
-        state.setStartsWithCurly(true);
+        state.startsWithObjectCurly(true);
         return state;
     }
 
@@ -798,7 +798,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Override
     public CodeRep reduceObjectBinding(@Nonnull ObjectBinding node, @Nonnull ImmutableList<CodeRep> properties) {
         CodeRep state = factory.brace(factory.commaSep(properties));
-        state.setStartsWithCurly(true);
+        state.startsWithObjectCurly(true);
         return state;
     }
 
@@ -806,7 +806,7 @@ public class CodeGen implements Reducer<CodeRep> {
     @Nonnull
     public CodeRep reduceObjectExpression(@Nonnull ObjectExpression node, @Nonnull ImmutableList<CodeRep> properties) {
         CodeRep result = factory.brace(factory.commaSep(properties));
-        result.setStartsWithCurly(true);
+        result.startsWithObjectCurly(true);
         return result;
     }
 
@@ -860,7 +860,7 @@ public class CodeGen implements Reducer<CodeRep> {
             state = seqVA(object, factory.token("."), factory.token(node.property));
         }
         state.setStartsWithLet(object.startsWithLet());
-        state.setStartsWithCurly(object.startsWithCurly());
+        state.startsWithObjectCurly(object.startsWithObjectCurly());
         state.setStartsWithLetSquareBracket(object.startsWithLetSquareBracket());
         state.setStartsWithFunctionOrClass(object.startsWithFunctionOrClass());
         return state;
@@ -877,7 +877,7 @@ public class CodeGen implements Reducer<CodeRep> {
             state = seqVA(object, factory.token("."), factory.token(node.property));
         }
         state.setStartsWithLet(object.startsWithLet());
-        state.setStartsWithCurly(object.startsWithCurly());
+        state.startsWithObjectCurly(object.startsWithObjectCurly());
         state.setStartsWithLetSquareBracket(object.startsWithLetSquareBracket());
         state.setStartsWithFunctionOrClass(object.startsWithFunctionOrClass());
         return state;
@@ -969,7 +969,7 @@ public class CodeGen implements Reducer<CodeRep> {
         }
         state = seqVA(state, factory.token("`"));
         if (node.tag.isJust()) {
-            state.setStartsWithCurly(tag.fromJust().startsWithCurly());
+            state.startsWithObjectCurly(tag.fromJust().startsWithObjectCurly());
             state.setStartsWithLetSquareBracket(tag.fromJust().startsWithLetSquareBracket());
             state.setStartsWithFunctionOrClass(tag.fromJust().startsWithFunctionOrClass());
         }
@@ -1023,7 +1023,7 @@ public class CodeGen implements Reducer<CodeRep> {
             return seqVA(factory.token(node.operator.getName()), operand);
         } else {
             CodeRep toReturn = toReturn = seqVA(operand, factory.token(node.operator.getName()));
-            toReturn.setStartsWithCurly(operand.startsWithCurly());
+            toReturn.startsWithObjectCurly(operand.startsWithObjectCurly());
             toReturn.setStartsWithLetSquareBracket(operand.startsWithLetSquareBracket());
             toReturn.setStartsWithFunctionOrClass(operand.startsWithFunctionOrClass());
             return toReturn;

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeRep.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeRep.java
@@ -100,7 +100,7 @@ public abstract class CodeRep {
 
     public static final class Token extends CodeRep {
         @Nonnull
-        private final String token;
+        public final String token;
 
         public Token(@Nonnull String token) {
             super();

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeRep.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/CodeRep.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 public abstract class CodeRep {
     protected boolean containsIn = false;
     protected boolean containsGroup = false;
-    protected boolean startsWithCurly = false;
+    protected boolean startsWithObjectCurly = false;
     protected boolean startsWithFunctionOrClass = false;
     protected boolean startsWithLet = false;
     protected boolean startsWithLetSquareBracket = false;
@@ -48,12 +48,12 @@ public abstract class CodeRep {
         this.containsGroup = containsGroup;
     }
 
-    public boolean startsWithCurly() {
-        return this.startsWithCurly;
+    public boolean startsWithObjectCurly() {
+        return this.startsWithObjectCurly;
     }
 
-    public void setStartsWithCurly(boolean startsWithCurly) {
-        this.startsWithCurly = startsWithCurly;
+    public void startsWithObjectCurly(boolean startsWithObjectCurly) {
+        this.startsWithObjectCurly = startsWithObjectCurly;
     }
 
     public boolean startsWithFunctionOrClass() {

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/WebSafeCodeGen.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/WebSafeCodeGen.java
@@ -113,7 +113,7 @@ public class WebSafeCodeGen extends CodeGen {
 		}
 		state = seqVA(state, factory.token("`"));
 		if (node.tag.isJust()) {
-			state.setStartsWithCurly(tag.fromJust().startsWithCurly());
+			state.startsWithObjectCurly(tag.fromJust().startsWithObjectCurly());
 			state.setStartsWithLetSquareBracket(tag.fromJust().startsWithLetSquareBracket());
 			state.setStartsWithFunctionOrClass(tag.fromJust().startsWithFunctionOrClass());
 		}

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/location/CodeGenWithLocation.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/location/CodeGenWithLocation.java
@@ -2,9 +2,11 @@ package com.shapesecurity.shift.es2016.codegen.location;
 
 import com.shapesecurity.functional.F2;
 import com.shapesecurity.functional.data.Maybe;
+import com.shapesecurity.shift.es2016.ast.ArrowExpression;
 import com.shapesecurity.shift.es2016.ast.Module;
 import com.shapesecurity.shift.es2016.ast.Node;
 import com.shapesecurity.shift.es2016.ast.Script;
+import com.shapesecurity.shift.es2016.codegen.CodeGen;
 import com.shapesecurity.shift.es2016.codegen.CodeRep;
 import com.shapesecurity.shift.es2016.parser.SourceLocation;
 import com.shapesecurity.shift.es2016.parser.SourceSpan;
@@ -35,7 +37,22 @@ public class CodeGenWithLocation extends WrappedReducer<CodeRep> {
 
 		CtorArgs(@Nonnull Reducer<CodeRep> codeGen) {
 			this.meta = new LocationMeta();
-			this.wrap = (node, codeRep) -> new CodeRepWithLocation(codeRep, node, this.meta);
+			this.wrap = (node, codeRep) -> {
+				if (node instanceof ArrowExpression && !CodeGen.isComplexArrowHead(((ArrowExpression) node).params)) {
+					if (codeRep instanceof CodeRep.Seq && ((CodeRep.Seq) codeRep).children.length > 0) {
+						CodeRep[] children = ((CodeRep.Seq) codeRep).children;
+						CodeRep bindingRep = children[0];
+						if (!(bindingRep instanceof CodeRepWithLocation)) {
+							// This is an awful hack. The default CodeGen replaces the CodeRep for a simple FormalParameters node of an ArrowExpression with a CodeRep for just the sole BindingIdentifier, so that it doesn't include parentheses.
+							// Since that means we lose our WithLocation wrapper, we have to manually add it back here.
+							CodeRepWithLocation bindingRepWithLocation = new CodeRepWithLocation(bindingRep, ((ArrowExpression) node).params.items.maybeHead().fromJust(), this.meta);
+							CodeRepWithLocation paramsRepWithLocation = new CodeRepWithLocation(bindingRepWithLocation, ((ArrowExpression) node).params, this.meta);
+							children[0] = paramsRepWithLocation;
+						}
+					}
+				}
+				return new CodeRepWithLocation(codeRep, node, this.meta);
+			};
 			this.reducer = codeGen;
 		}
 	}

--- a/src/main/java/com/shapesecurity/shift/es2016/codegen/location/CodeRepWithLocation.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/codegen/location/CodeRepWithLocation.java
@@ -49,13 +49,13 @@ public class CodeRepWithLocation extends CodeRep {
 	}
 
 	@Override
-	public boolean startsWithCurly() {
-		return this.inner.startsWithCurly();
+	public boolean startsWithObjectCurly() {
+		return this.inner.startsWithObjectCurly();
 	}
 
 	@Override
-	public void setStartsWithCurly(boolean startsWithCurly) {
-		this.inner.setStartsWithCurly(startsWithCurly);
+	public void startsWithObjectCurly(boolean startsWithObjectCurly) {
+		this.inner.startsWithObjectCurly(startsWithObjectCurly);
 	}
 
 	@Override

--- a/src/main/java/com/shapesecurity/shift/es2016/parser/GenericParser.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/parser/GenericParser.java
@@ -195,11 +195,11 @@ public abstract class GenericParser<AdditionalStateT> extends Tokenizer {
         this.inFunctionBody = true;
         this.module = false;
 
-        this.expect(TokenType.LBRACE);
         AdditionalStateT startState = this.startNode();
+        this.expect(TokenType.LBRACE);
         FunctionBody body = this.parseBody(this::parseStatementListItem, FunctionBody::new);
-        body = this.finishNode(startState, body);
         this.expect(TokenType.RBRACE);
+        body = this.finishNode(startState, body);
 
         this.inFunctionBody = oldInFunctionBody;
         this.module = oldModule;

--- a/src/main/java/com/shapesecurity/shift/es2016/parser/ParserWithLocation.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/parser/ParserWithLocation.java
@@ -46,14 +46,6 @@ public class ParserWithLocation {
 				// Special case: the start/end of the whole-program node is the whole text including leading and trailing whitespace.
 				locations = locations.put(node, new SourceSpan(Maybe.empty(), new SourceLocation(0, 0, 0), new SourceLocation(this.startLine, this.startIndex - this.startLineStart, this.startIndex)));
 				return node;
-			} else if (node instanceof FunctionBody) {
-				FunctionBody body = (FunctionBody) node;
-				if (body.directives.isEmpty() && body.statements.isEmpty()) {
-					// Special case: a function body which contains no nodes spans no tokens, so the usual logic of "start of first contained token through end of last contained token" doesn't work. We choose to define it to start and end immediately after the opening brace.
-					SourceLocation endLocation = this.getLastTokenEndLocation();
-					locations = locations.put(node, new SourceSpan(Maybe.empty(), endLocation, endLocation));
-					return node;
-				}
 			} else if (node instanceof FormalParameters) {
 				FormalParameters parameters = (FormalParameters) node;
 				if (parameters.items.isEmpty() && parameters.rest.isNothing()) {

--- a/src/main/java/com/shapesecurity/shift/es2016/parser/ParserWithLocation.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/parser/ParserWithLocation.java
@@ -6,7 +6,6 @@ import com.shapesecurity.functional.data.Maybe;
 import com.shapesecurity.shift.es2016.ast.BindingIdentifier;
 import com.shapesecurity.shift.es2016.ast.ExpressionTemplateElement;
 import com.shapesecurity.shift.es2016.ast.FormalParameters;
-import com.shapesecurity.shift.es2016.ast.FunctionBody;
 import com.shapesecurity.shift.es2016.ast.Module;
 import com.shapesecurity.shift.es2016.ast.Node;
 import com.shapesecurity.shift.es2016.ast.Script;
@@ -46,14 +45,6 @@ public class ParserWithLocation {
 				// Special case: the start/end of the whole-program node is the whole text including leading and trailing whitespace.
 				locations = locations.put(node, new SourceSpan(Maybe.empty(), new SourceLocation(0, 0, 0), new SourceLocation(this.startLine, this.startIndex - this.startLineStart, this.startIndex)));
 				return node;
-			} else if (node instanceof FormalParameters) {
-				FormalParameters parameters = (FormalParameters) node;
-				if (parameters.items.isEmpty() && parameters.rest.isNothing()) {
-					// Special case: formal parameters which contains no nodes span no tokens, so the usual logic of "start of first contained token through end of last contained token" doesn't work. We choose to define it to start and end immediately after the opening parenthesis.
-					SourceLocation endLocation = this.getLastTokenEndLocation();
-					locations = locations.put(node, new SourceSpan(Maybe.empty(), endLocation, endLocation));
-					return node;
-				}
 			} else if (node instanceof BindingIdentifier && ((BindingIdentifier) node).name.equals("*default*")) {
 				// Special case: synthetic BindingIdentifier for export-default declarations should not have a location
 				return node;

--- a/src/test/java/com/shapesecurity/shift/es2016/codegen/CodeGenTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2016/codegen/CodeGenTest.java
@@ -25,6 +25,7 @@ import com.shapesecurity.shift.es2016.ast.EmptyStatement;
 import com.shapesecurity.shift.es2016.ast.ExpressionStatement;
 import com.shapesecurity.shift.es2016.ast.ForInStatement;
 import com.shapesecurity.shift.es2016.ast.ForStatement;
+import com.shapesecurity.shift.es2016.ast.FormalParameters;
 import com.shapesecurity.shift.es2016.ast.IdentifierExpression;
 import com.shapesecurity.shift.es2016.ast.IfStatement;
 import com.shapesecurity.shift.es2016.ast.LabeledStatement;

--- a/src/test/java/com/shapesecurity/shift/es2016/parser/miscellaneous/LocationTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2016/parser/miscellaneous/LocationTest.java
@@ -222,7 +222,7 @@ public class LocationTest extends TestCase {
 		Statement statement = (Statement) this.tree.items.maybeHead().fromJust();
 		Expression expression = ((ExpressionStatement) statement).expression;
 		FormalParameters params = ((ArrowExpression) expression).params;
-		checkText(params, "a,b");
+		checkText(params, "(a,b)");
 
 		FunctionBody body = (FunctionBody) ((ArrowExpression) expression).body;
 		checkLocation(body, new SourceSpan(
@@ -272,8 +272,8 @@ public class LocationTest extends TestCase {
 		FormalParameters params = functionDeclaration.params;
 		checkLocation(params, new SourceSpan(
 				Maybe.empty(),
-				new SourceLocation(0, 24, 24),
-				new SourceLocation(0, 24, 24) // i.e. immediately after the opening parenthesis, not including any whitespace.
+				new SourceLocation(0, 23, 23),
+				new SourceLocation(1, 1, 26) // i.e. around the parentheses, including internal whitespace.
 		));
 
 		FunctionBody body = functionDeclaration.body;

--- a/src/test/java/com/shapesecurity/shift/es2016/parser/miscellaneous/LocationTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2016/parser/miscellaneous/LocationTest.java
@@ -227,8 +227,8 @@ public class LocationTest extends TestCase {
 		FunctionBody body = (FunctionBody) ((ArrowExpression) expression).body;
 		checkLocation(body, new SourceSpan(
 				Maybe.empty(),
-				new SourceLocation(0, 8, 8),
-				new SourceLocation(0, 8, 8) // i.e. not including the braces.
+				new SourceLocation(0, 7, 7),
+				new SourceLocation(0, 9, 9) // i.e. including the braces.
 		));
 	}
 
@@ -279,8 +279,8 @@ public class LocationTest extends TestCase {
 		FunctionBody body = functionDeclaration.body;
 		checkLocation(body, new SourceSpan(
 				Maybe.empty(),
-				new SourceLocation(1, 2, 27),
-				new SourceLocation(1, 2, 27) // i.e. immediately after the brace, not including any whitespace.
+				new SourceLocation(1, 1, 26),
+				new SourceLocation(2, 1, 29) // i.e. around the braces, including internal whitespace.
 		));
 	}
 }


### PR DESCRIPTION
This amounts to a partial revert of #134 and #135, though it also involves changing the since-added CodeGenWithLocation, including a fairly awful hack.