### PR TITLE
Mark a\*\*b as not an assignment target

### DIFF
--- a/src/main/java/com/shapesecurity/shift/es2016/parser/GenericParser.java
+++ b/src/main/java/com/shapesecurity/shift/es2016/parser/GenericParser.java
@@ -1333,6 +1333,8 @@ public abstract class GenericParser<AdditionalStateT> extends Tokenizer {
         }
         this.lex();
 
+        this.isAssignmentTarget = this.isBindingElement = false;
+
         Expression right = this.isolateCoverGrammar(this::parseExponentiationExpression).left().fromJust();
         return Either3.left(this.finishNode(startState, new BinaryExpression(left.left().fromJust(), BinaryOperator.Exp, right)));
     }

--- a/src/test/java/com/shapesecurity/shift/es2016/Test262/PassTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2016/Test262/PassTest.java
@@ -84,9 +84,6 @@ public class PassTest {
 		"cbc644a20893a549.js",
 		"ec97990c2cc5e0e8.js",
 
-		// BUG: deserializer breaks on **
-		"988e362ed9ddcac5.js",
-
 		// BUG: for-in destructing containing in breaks doesn't work
 		"c546a199e87abaad.js",
 


### PR DESCRIPTION
This is on top of #156. It should land after it, and be rebased on top.