### PR TITLE
 Use StringBuilder for tokenizing string literals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2016</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2016</artifactId>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>1.2.2</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>


### PR DESCRIPTION
This significantly improves performance when scanning very long strings.

Includes version bump commits, so please **rebase**, not merge.