### PR TITLE
Deterministic variable ordering, version 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2017</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2017</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.2.0</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>com.shapesecurity</groupId>
 			<artifactId>shape-functional-java</artifactId>
-			<version>2.5.2</version>
+			<version>2.5.4</version>
 		</dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/com/shapesecurity/shift/es2017/scope/GlobalScope.java
+++ b/src/main/java/com/shapesecurity/shift/es2017/scope/GlobalScope.java
@@ -23,16 +23,25 @@ import com.shapesecurity.functional.data.NonEmptyImmutableList;
 import com.shapesecurity.shift.es2017.ast.Node;
 
 import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class GlobalScope extends Scope {
     GlobalScope(
             @Nonnull ImmutableList<Scope> children,
             @Nonnull ImmutableList<Variable> variables,
             @Nonnull HashTable<String, NonEmptyImmutableList<Reference>> through,
-            @Nonnull Node astNode) {
+            @Nonnull Node astNode,
+            @Nonnull ScopeAnalyzer.IdCounter counter) {
         super(children, variables, through, Type.Global, true, astNode);
-        for (Pair<String, NonEmptyImmutableList<Reference>> var : through.entries()) {
-            this.variables.put(var.left(), new Variable(var.left(), var.right(), ImmutableList.empty()));
+        List<Pair<String, NonEmptyImmutableList<Reference>>> throughSorted = StreamSupport.stream(Spliterators.spliteratorUnknownSize(through.iterator(), Spliterator.ORDERED), false)
+            .sorted(Comparator.comparing(o -> o.left)).collect(Collectors.toList());
+        for (Pair<String, NonEmptyImmutableList<Reference>> var : throughSorted) {
+            this.variables.put(var.left(), new Variable(var.left(), var.right(), ImmutableList.empty(), counter.next()));
         }
     }
 }

--- a/src/main/java/com/shapesecurity/shift/es2017/scope/Variable.java
+++ b/src/main/java/com/shapesecurity/shift/es2017/scope/Variable.java
@@ -17,10 +17,11 @@
 package com.shapesecurity.shift.es2017.scope;
 
 import com.shapesecurity.functional.data.ImmutableList;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 
-public class Variable {
+public class Variable implements Comparable<Variable> {
     /**
      * Variable name *
      */
@@ -37,12 +38,24 @@ public class Variable {
     @Nonnull
     public final ImmutableList<Declaration> declarations;
 
+    /**
+     * counter used for deterministic ordering of variables
+     */
+    private final int variableIndex;
+
     public Variable(
             @Nonnull String name,
             @Nonnull ImmutableList<Reference> references,
-            @Nonnull ImmutableList<Declaration> declarations) {
+            @Nonnull ImmutableList<Declaration> declarations,
+            int variableIndex) {
         this.name = name;
         this.references = references;
         this.declarations = declarations;
+        this.variableIndex = variableIndex;
+    }
+
+    @Override
+    public int compareTo(@NotNull Variable o) {
+        return this.variableIndex - o.variableIndex;
     }
 }

--- a/src/test/java/com/shapesecurity/shift/es2017/scope/VariableOrderingTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2017/scope/VariableOrderingTest.java
@@ -1,0 +1,46 @@
+package com.shapesecurity.shift.es2017.scope;
+
+import com.shapesecurity.shift.es2017.ast.Script;
+import com.shapesecurity.shift.es2017.parser.JsError;
+import com.shapesecurity.shift.es2017.parser.Parser;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class VariableOrderingTest {
+
+	@Test
+	public void testVariableOrdering() throws JsError {
+		StringBuilder js = new StringBuilder();
+		List<String> expectedOrder = new ArrayList<>();
+		for (int i = 0; i < 100; ++i) {
+			int x = 100 - i;
+			js.append("let i").append(x).append(" = 0;");
+			expectedOrder.add("i" + x);
+		}
+		expectedOrder.sort(String::compareTo);
+		Script script = Parser.parseScript(js.toString());
+		GlobalScope scope = ScopeAnalyzer.analyze(script);
+		Map<Variable, String> nameMap = new HashMap<>();
+		Set<Variable> variableSet = new HashSet<>();
+		scope.children.maybeHead().fromJust().variables().forEach(variable -> {
+			nameMap.put(variable, variable.name);
+			variableSet.add(variable);
+		});
+		List<Variable> mapVariables = new ArrayList<>(nameMap.keySet());
+		mapVariables.sort(Variable::compareTo);
+		List<Variable> setVariables = new ArrayList<>(variableSet);
+		setVariables.sort(Variable::compareTo);
+		assertEquals(expectedOrder, mapVariables.stream().map(variable -> variable.name).collect(Collectors.toList()));
+		assertEquals(expectedOrder, setVariables.stream().map(variable -> variable.name).collect(Collectors.toList()));
+	}
+
+}


### PR DESCRIPTION
Allows deterministic ordering after being used in a `HashMap`/`HashTable`/other non-deterministic structure.