### PR TITLE
back out comparable variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2017</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.2.1</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.shapesecurity.shift</groupId>
 	<artifactId>es2017</artifactId>
-	<version>1.2.1</version>
+	<version>1.2.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Shift AST</name>

--- a/src/main/java/com/shapesecurity/shift/es2017/scope/GlobalScope.java
+++ b/src/main/java/com/shapesecurity/shift/es2017/scope/GlobalScope.java
@@ -35,13 +35,12 @@ public class GlobalScope extends Scope {
             @Nonnull ImmutableList<Scope> children,
             @Nonnull ImmutableList<Variable> variables,
             @Nonnull HashTable<String, NonEmptyImmutableList<Reference>> through,
-            @Nonnull Node astNode,
-            @Nonnull ScopeAnalyzer.IdCounter counter) {
+            @Nonnull Node astNode) {
         super(children, variables, through, Type.Global, true, astNode);
         List<Pair<String, NonEmptyImmutableList<Reference>>> throughSorted = StreamSupport.stream(Spliterators.spliteratorUnknownSize(through.iterator(), Spliterator.ORDERED), false)
             .sorted(Comparator.comparing(o -> o.left)).collect(Collectors.toList());
         for (Pair<String, NonEmptyImmutableList<Reference>> var : throughSorted) {
-            this.variables.put(var.left(), new Variable(var.left(), var.right(), ImmutableList.empty(), counter.next()));
+            this.variables.put(var.left(), new Variable(var.left(), var.right(), ImmutableList.empty()));
         }
     }
 }

--- a/src/main/java/com/shapesecurity/shift/es2017/scope/Variable.java
+++ b/src/main/java/com/shapesecurity/shift/es2017/scope/Variable.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 
-public class Variable implements Comparable<Variable> {
+public class Variable {
     /**
      * Variable name *
      */
@@ -38,24 +38,12 @@ public class Variable implements Comparable<Variable> {
     @Nonnull
     public final ImmutableList<Declaration> declarations;
 
-    /**
-     * counter used for deterministic ordering of variables
-     */
-    private final int variableIndex;
-
     public Variable(
             @Nonnull String name,
             @Nonnull ImmutableList<Reference> references,
-            @Nonnull ImmutableList<Declaration> declarations,
-            int variableIndex) {
+            @Nonnull ImmutableList<Declaration> declarations) {
         this.name = name;
         this.references = references;
         this.declarations = declarations;
-        this.variableIndex = variableIndex;
-    }
-
-    @Override
-    public int compareTo(@NotNull Variable o) {
-        return this.variableIndex - o.variableIndex;
     }
 }

--- a/src/test/java/com/shapesecurity/shift/es2017/scope/VariableOrderingTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2017/scope/VariableOrderingTest.java
@@ -3,19 +3,21 @@ package com.shapesecurity.shift.es2017.scope;
 import com.shapesecurity.shift.es2017.ast.Script;
 import com.shapesecurity.shift.es2017.parser.JsError;
 import com.shapesecurity.shift.es2017.parser.Parser;
+import com.shapesecurity.shift.es2017.parser.ParserWithLocation;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 public class VariableOrderingTest {
+
+	private static void getVariables(Scope scope, ArrayList<Variable> out) {
+		out.addAll(scope.variables());
+		scope.children.forEach(child -> getVariables(child, out));
+	}
+
+
 
 	@Test
 	public void testVariableOrdering() throws JsError {
@@ -24,23 +26,44 @@ public class VariableOrderingTest {
 		for (int i = 0; i < 100; ++i) {
 			int x = 100 - i;
 			js.append("let i").append(x).append(" = 0;");
+			js.append("{ let i").append(x).append(" = 0; }");
+			js.append("(function(){ let i").append(x).append(" = 0; });");
 			expectedOrder.add("i" + x);
 		}
 		expectedOrder.sort(String::compareTo);
-		Script script = Parser.parseScript(js.toString());
+		ParserWithLocation originalParser = new ParserWithLocation();
+		Script script = originalParser.parseScript(js.toString());
 		GlobalScope scope = ScopeAnalyzer.analyze(script);
-		Map<Variable, String> nameMap = new HashMap<>();
-		Set<Variable> variableSet = new HashSet<>();
-		scope.children.maybeHead().fromJust().variables().forEach(variable -> {
-			nameMap.put(variable, variable.name);
-			variableSet.add(variable);
-		});
-		List<Variable> mapVariables = new ArrayList<>(nameMap.keySet());
-		mapVariables.sort(Variable::compareTo);
-		List<Variable> setVariables = new ArrayList<>(variableSet);
-		setVariables.sort(Variable::compareTo);
-		assertEquals(expectedOrder, mapVariables.stream().map(variable -> variable.name).collect(Collectors.toList()));
-		assertEquals(expectedOrder, setVariables.stream().map(variable -> variable.name).collect(Collectors.toList()));
+		ArrayList<Variable> originalVariableOrder = new ArrayList<>();
+		getVariables(scope, originalVariableOrder);
+
+		for (int i = 0; i < 10; ++i) {
+			ParserWithLocation newParser = new ParserWithLocation();
+			Script newScript = newParser.parseScript(js.toString());
+			GlobalScope newScope = ScopeAnalyzer.analyze(newScript);
+			ArrayList<Variable> newVariableOrder = new ArrayList<>(originalVariableOrder.size());
+			getVariables(newScope, newVariableOrder);
+
+			Assert.assertEquals(originalVariableOrder.size(), newVariableOrder.size());
+
+			for (int j = 0; j < originalVariableOrder.size(); ++j) {
+				Variable originalVar = originalVariableOrder.get(j);
+				Variable newVar = newVariableOrder.get(j);
+
+				Assert.assertEquals(
+					originalVar.declarations.isEmpty(),
+					newVar.declarations.isEmpty()
+				);
+
+				if (originalVar.declarations.isNotEmpty()) {
+					Assert.assertEquals(
+						originalParser.getLocation(originalVar.declarations.maybeHead().fromJust().node).fromJust().start.offset,
+						newParser.getLocation(newVar.declarations.maybeHead().fromJust().node).fromJust().start.offset
+					);
+				}
+			}
+
+		}
 	}
 
 }


### PR DESCRIPTION
The change to the Variable constructor in #244 was not backwards compatible. This backs that portion of the PR out, with a patch version bump (so please **rebase**, not squash). It keeps the fix to make the variable list in scope options deterministic, and modifies the test to assert that is the case.