### PR TITLE
only use exponents for numbers > 1000

### DIFF
--- a/src/main/java/com/shapesecurity/shift/es2018/utils/D2A.java
+++ b/src/main/java/com/shapesecurity/shift/es2018/utils/D2A.java
@@ -150,7 +150,7 @@ public final class D2A {
             }
             for (int i = 0; i < s.length(); i++) {
                 if (s.charAt(s.length() - 1 - i) != '0') {
-                    if (i > 1) {
+                    if (i > 2) {
                         return s.substring(0, s.length() - i) + "e" + i;
                     } else {
                         return s;

--- a/src/test/java/com/shapesecurity/shift/es2018/codegen/CodeGenTest.java
+++ b/src/test/java/com/shapesecurity/shift/es2018/codegen/CodeGenTest.java
@@ -560,6 +560,9 @@ public class CodeGenTest {
         test("0", "0b0");
         test("1");
         test("2");
+        test("20");
+        test("200");
+        test("2e4");
         test("0x38D7EA4C68001", "1000000000000001");
         test("15e5", "1500000");
         test("155e3", "155000");


### PR DESCRIPTION
This matches the [javascript implementation](https://github.com/shapesecurity/shift-codegen-js/blob/fed66a3ac56462b98c3b81ad2474c62ec3428c7d/src/token-stream.js#L38).